### PR TITLE
Add stochastic argmax a and learning_rate parameter

### DIFF
--- a/src/mdptoolbox/mdp.py
+++ b/src/mdptoolbox/mdp.py
@@ -1068,7 +1068,10 @@ class QLearning(MDP):
             pn = _np.random.random()
             if pn < (1 - (1 / _math.log(n + 2))):
                 # optimal_action = self.Q[s, :].max()
-                a = self.Q[s, :].argmax()
+                s_Q = self.Q[s, :]
+                a = s_Q.argmax()
+                if _np.argwhere(s_Q == s_Q[a]).shape[0] > 1:
+                    a = _np.random.choice(_np.argwhere(s_Q == s_Q[a]).flatten())
             else:
                 a = _np.random.randint(0, self.A)
 

--- a/src/mdptoolbox/mdp.py
+++ b/src/mdptoolbox/mdp.py
@@ -971,6 +971,9 @@ class QLearning(MDP):
         By default we run a check on the ``transitions`` and ``rewards``
         arguments to make sure they describe a valid MDP. You can set this
         argument to True in order to skip this check.
+    learning_rate : function
+        function of n that returns the Q learning rate.
+        default is lambda n: (1 / sqrt(n + 2))
 
     Data Attributes
     ---------------
@@ -1023,7 +1026,7 @@ class QLearning(MDP):
     """
 
     def __init__(self, transitions, reward, discount, n_iter=10000,
-                 skip_check=False):
+                 skip_check=False, learning_rate=None):
         # Initialise a Q-learning MDP.
 
         # The following check won't be done in MDP()'s initialisation, so let's
@@ -1043,6 +1046,10 @@ class QLearning(MDP):
         self.R = reward
 
         self.discount = discount
+
+        self.learning_rate = learning_rate
+        if self.learning_rate is None:
+            self.learning_rate = lambda n: 1 / (_math.sqrt(n + 2))
 
         # Initialisations
         self.Q = _np.zeros((self.S, self.A))
@@ -1094,7 +1101,7 @@ class QLearning(MDP):
             # Updating the value of Q
             # Decaying update coefficient (1/sqrt(n+2)) can be changed
             delta = r + self.discount * self.Q[s_new, :].max() - self.Q[s, a]
-            dQ = (1 / _math.sqrt(n + 2)) * delta
+            dQ = self.learning_rate(n) * delta
             self.Q[s, a] = self.Q[s, a] + dQ
 
             # current state is updated


### PR DESCRIPTION
Adds stochastic argmax if multiple maximum actions (default numpy is to pick the first occurrence of the maximum) and add learning_rate as another parameter, as a function of n.